### PR TITLE
Avoid classloading client-only classes on dedicated servers; optimize `CatalogScreen#render`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ loader_version=0.16.14
 loom_version=1.11-SNAPSHOT
 
 # Project
-mod_version=1.0.1-1.21.1+fabric
+mod_version=1.0.2-1.21.1+fabric
 maven_group=net.edu.resprouted
 archives_base_name=resprouted
 

--- a/src/main/java/net/edu/resprouted/book/CatalogScreen.java
+++ b/src/main/java/net/edu/resprouted/book/CatalogScreen.java
@@ -66,12 +66,6 @@ public class CatalogScreen extends Screen {
     }
 
     @Override
-    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
-        this.renderBackground(context, mouseX, mouseY, delta);
-        super.render(context, mouseX, mouseY, delta);
-    }
-
-    @Override
     public void renderBackground(DrawContext context, int mouseX, int mouseY, float delta) {
         super.renderInGameBackground(context);
         context.drawTexture(BACKGROUND, bookX, bookY, 0, 0, BOOK_WIDTH, BOOK_HEIGHT, TEXTURE_SIZE, TEXTURE_SIZE);

--- a/src/main/java/net/edu/resprouted/item/ModItems.java
+++ b/src/main/java/net/edu/resprouted/item/ModItems.java
@@ -11,6 +11,8 @@ import net.edu.resprouted.fluid.ModFluids;
 import net.edu.resprouted.item.custom.*;
 import net.edu.resprouted.registry.ResproutedBoatTypes;
 import net.edu.resprouted.util.TextUtils;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.component.type.CustomModelDataComponent;
@@ -101,10 +103,15 @@ public class ModItems {
             }
 
             if (world.isClient) {
-                MinecraftClient.getInstance().setScreen(new CatalogScreen());
+                this.openCatalogScreen();
             }
 
             return TypedActionResult.success(stack);
+        }
+
+        @Environment(EnvType.CLIENT)
+        private void openCatalogScreen() {
+            MinecraftClient.getInstance().setScreen(new CatalogScreen());
         }
     });
 


### PR DESCRIPTION
- `Screen#render` already calls `renderBackground`, so remove the overridden `Screen#render` method to avoid rendering the background twice
- Add separate method for opening the catalog screen, annotated with `@Environment(EnvType.CLIENT)`, to avoid classloading `Screen` on the wrong side (fixes a crash during startup on dedicated servers)